### PR TITLE
:sparkles: 异色主题平滑切换 & 语言切换按钮配色跟随

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -13,6 +13,40 @@
   font-style: normal;
 }
 
+// MD3 tokens + body wash colors registered as <color> so they animate when transitioned.
+// Without @property, CSS custom properties are typeless and snap on change.
+// 浏览器若不支持 @property，下面的 transition 会自动退化为 snap（与硬切换一致）。
+@property --primary-color { syntax: '<color>'; inherits: true; initial-value: #006a8e; }
+@property --on-primary-color { syntax: '<color>'; inherits: true; initial-value: #ffffff; }
+@property --primary-container-color { syntax: '<color>'; inherits: true; initial-value: #c6e7ff; }
+@property --on-primary-container-color { syntax: '<color>'; inherits: true; initial-value: #001e2c; }
+@property --secondary-color { syntax: '<color>'; inherits: true; initial-value: #58636d; }
+@property --on-secondary-color { syntax: '<color>'; inherits: true; initial-value: #ffffff; }
+@property --secondary-container-color { syntax: '<color>'; inherits: true; initial-value: #dce4ec; }
+@property --on-secondary-container-color { syntax: '<color>'; inherits: true; initial-value: #151d24; }
+@property --tertiary-color { syntax: '<color>'; inherits: true; initial-value: #806b57; }
+@property --on-tertiary-color { syntax: '<color>'; inherits: true; initial-value: #ffffff; }
+@property --tertiary-container-color { syntax: '<color>'; inherits: true; initial-value: #f4dec9; }
+@property --on-tertiary-container-color { syntax: '<color>'; inherits: true; initial-value: #2c1708; }
+@property --error-color { syntax: '<color>'; inherits: true; initial-value: #ba1a1a; }
+@property --on-error-color { syntax: '<color>'; inherits: true; initial-value: #ffffff; }
+@property --error-container-color { syntax: '<color>'; inherits: true; initial-value: #ffdad6; }
+@property --on-error-container-color { syntax: '<color>'; inherits: true; initial-value: #410002; }
+@property --background-color { syntax: '<color>'; inherits: true; initial-value: #f8faff; }
+@property --on-background-color { syntax: '<color>'; inherits: true; initial-value: #171c21; }
+@property --surface-color { syntax: '<color>'; inherits: true; initial-value: #f8faff; }
+@property --surface-container-low-color { syntax: '<color>'; inherits: true; initial-value: #f0f4fa; }
+@property --surface-container-color { syntax: '<color>'; inherits: true; initial-value: #e8edf5; }
+@property --surface-container-high-color { syntax: '<color>'; inherits: true; initial-value: #dee6ef; }
+@property --on-surface-color { syntax: '<color>'; inherits: true; initial-value: #171c21; }
+@property --outline-color { syntax: '<color>'; inherits: true; initial-value: #707780; }
+@property --surface-variant-color { syntax: '<color>'; inherits: true; initial-value: #dde3eb; }
+@property --on-surface-variant-color { syntax: '<color>'; inherits: true; initial-value: #414850; }
+@property --scrim-color { syntax: '<color>'; inherits: true; initial-value: rgba(18, 29, 38, 0.44); }
+@property --bg-wash-1 { syntax: '<color>'; inherits: true; initial-value: rgba(198, 231, 255, 0.78); }
+@property --bg-wash-2 { syntax: '<color>'; inherits: true; initial-value: rgba(244, 222, 201, 0.38); }
+@property --bg-wash-3 { syntax: '<color>'; inherits: true; initial-value: rgba(221, 227, 235, 0.58); }
+
 a {
   text-decoration: none;
   color: inherit;
@@ -81,6 +115,10 @@ body {
 
   --card-background-color: var(--surface-container-color);
   --scrim-color: rgba(18, 29, 38, 0.44);
+
+  --bg-wash-1: rgba(198, 231, 255, 0.78);
+  --bg-wash-2: rgba(244, 222, 201, 0.38);
+  --bg-wash-3: rgba(221, 227, 235, 0.58);
 }
 
 // Shiny palette — MD3 Expressive scheme derived from public/avatar.png
@@ -122,14 +160,18 @@ html.shiny body {
 
   --card-background-color: var(--surface-container-color);
   --scrim-color: rgba(48, 32, 8, 0.46);
+
+  --bg-wash-1: rgba(255, 221, 174, 0.78);
+  --bg-wash-2: rgba(255, 218, 210, 0.42);
+  --bg-wash-3: rgba(237, 225, 200, 0.62);
 }
 
 html,
 body {
   background:
-    linear-gradient(145deg, rgba(198, 231, 255, 0.78), transparent 34%),
-    linear-gradient(25deg, rgba(244, 222, 201, 0.38), transparent 42%),
-    linear-gradient(315deg, rgba(221, 227, 235, 0.58), transparent 46%), var(--background-color);
+    linear-gradient(145deg, var(--bg-wash-1), transparent 34%),
+    linear-gradient(25deg, var(--bg-wash-2), transparent 42%),
+    linear-gradient(315deg, var(--bg-wash-3), transparent 46%), var(--background-color);
   background-size:
     220% 220%,
     240% 240%,
@@ -144,21 +186,40 @@ body {
   animation: home-bg-wave 28s ease-in-out infinite;
   color: var(--on-background-color);
   overflow: hidden;
-}
 
-html.shiny,
-html.shiny body {
-  background:
-    linear-gradient(145deg, rgba(255, 221, 174, 0.78), transparent 34%),
-    linear-gradient(25deg, rgba(255, 218, 210, 0.42), transparent 42%),
-    linear-gradient(315deg, rgba(237, 225, 200, 0.62), transparent 46%), var(--background-color);
-  background-size:
-    220% 220%,
-    240% 240%,
-    260% 260%,
-    100% 100%;
-  background-repeat: no-repeat;
-  animation: home-bg-wave 28s ease-in-out infinite;
+  // 主题切换平滑过渡。不支持 @property 的浏览器中上面注册的变量仍是无类型 token，
+  // 下面的 transition 对它们没有可插值类型 → 自动退回 snap，无需 JS 检测。
+  transition:
+    --primary-color 700ms var(--motion-expressive),
+    --on-primary-color 700ms var(--motion-expressive),
+    --primary-container-color 700ms var(--motion-expressive),
+    --on-primary-container-color 700ms var(--motion-expressive),
+    --secondary-color 700ms var(--motion-expressive),
+    --on-secondary-color 700ms var(--motion-expressive),
+    --secondary-container-color 700ms var(--motion-expressive),
+    --on-secondary-container-color 700ms var(--motion-expressive),
+    --tertiary-color 700ms var(--motion-expressive),
+    --on-tertiary-color 700ms var(--motion-expressive),
+    --tertiary-container-color 700ms var(--motion-expressive),
+    --on-tertiary-container-color 700ms var(--motion-expressive),
+    --error-color 700ms var(--motion-expressive),
+    --on-error-color 700ms var(--motion-expressive),
+    --error-container-color 700ms var(--motion-expressive),
+    --on-error-container-color 700ms var(--motion-expressive),
+    --background-color 700ms var(--motion-expressive),
+    --on-background-color 700ms var(--motion-expressive),
+    --surface-color 700ms var(--motion-expressive),
+    --surface-container-low-color 700ms var(--motion-expressive),
+    --surface-container-color 700ms var(--motion-expressive),
+    --surface-container-high-color 700ms var(--motion-expressive),
+    --on-surface-color 700ms var(--motion-expressive),
+    --outline-color 700ms var(--motion-expressive),
+    --surface-variant-color 700ms var(--motion-expressive),
+    --on-surface-variant-color 700ms var(--motion-expressive),
+    --scrim-color 700ms var(--motion-expressive),
+    --bg-wash-1 700ms var(--motion-expressive),
+    --bg-wash-2 700ms var(--motion-expressive),
+    --bg-wash-3 700ms var(--motion-expressive);
 }
 
 @keyframes home-bg-wave {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -71,7 +71,7 @@ bus?.on('set-background-cover', (value: boolean) => {
     border-radius: 999px
     min-width: 3rem
     min-height: 3rem
-    background: rgba(198, 231, 255, 0.72)
+    background: color-mix(in srgb, var(--primary-container-color) 72%, transparent)
     color: var(--on-primary-container-color) !important
     transition: transform .18s var(--motion-bounce), background-color .18s var(--motion-expressive)
 


### PR DESCRIPTION
用 @property 把 30 个 MD3 颜色 token + 3 个 body 渐变色注册为 <color>， 在 html, body 上声明 700ms transition，shiny 类切换时由浏览器逐帧插值。 body 多层渐变改用 var(--bg-wash-N) 驱动，整页（含背景渐变）一并淡出淡入。
不支持 @property 的浏览器中变量保持无类型，transition 自动失效退回 snap，无需 JS 介入。

MainLayout 语言切换按钮把硬编码 rgba(198,231,255,.72) 换成
color-mix(in srgb, var(--primary-container-color) 72%, transparent)， shiny 模式下跟随金色主题，不再残留蓝色。